### PR TITLE
Fix go-staticcheck failures (ST1005) in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ viper.AddConfigPath("$HOME/.appname")  // call multiple times to add many search
 viper.AddConfigPath(".")               // optionally look for config in the working directory
 err := viper.ReadInConfig() // Find and read the config file
 if err != nil { // Handle errors reading the config file
-	panic(fmt.Errorf("Fatal error config file: %w \n", err))
+	panic(fmt.Errorf("fatal error config file: %w", err))
 }
 ```
 


### PR DESCRIPTION
Minor fix to example code, which fails static checks related to acceptable formats of error strings if used.